### PR TITLE
Queries on Order Table

### DIFF
--- a/src/java/com/busy/engine/dao/CustomerOrderDaoImpl.java
+++ b/src/java/com/busy/engine/dao/CustomerOrderDaoImpl.java
@@ -161,7 +161,7 @@
                     getRecordById("customer", customerOrder.getCustomerId().toString());
                     customerOrder.setCustomer(Customer.process(rs));               
                 
-                    getRecordById("order", customerOrder.getOrderId().toString());
+                    getRecordById("`order`", customerOrder.getOrderId().toString());
                     customerOrder.setOrder(Order.process(rs));               
                 
                     getRecordById("discount", customerOrder.getDiscountId().toString());
@@ -260,7 +260,7 @@
                                 getRecordById("customer", customerOrder.getCustomerId().toString());
                                 customerOrder.setCustomer(Customer.process(rs));               
                             
-                                getRecordById("order", customerOrder.getOrderId().toString());
+                                getRecordById("`order`", customerOrder.getOrderId().toString());
                                 customerOrder.setOrder(Order.process(rs));               
                             
                                 getRecordById("discount", customerOrder.getDiscountId().toString());
@@ -298,7 +298,7 @@
                                 getRecordById("customer", customerOrder.getCustomerId().toString());
                                 customerOrder.setCustomer(Customer.process(rs));               
                             
-                                getRecordById("order", customerOrder.getOrderId().toString());
+                                getRecordById("`order`", customerOrder.getOrderId().toString());
                                 customerOrder.setOrder(Order.process(rs));               
                             
                                 getRecordById("discount", customerOrder.getDiscountId().toString());
@@ -519,7 +519,7 @@
                             getRecordById("customer", customer_order.getCustomerId().toString());
                             customer_order.setCustomer(Customer.process(rs));                                       
                     
-                            getRecordById("order", customer_order.getOrderId().toString());
+                            getRecordById("`order`", customer_order.getOrderId().toString());
                             customer_order.setOrder(Order.process(rs));                                       
                     
                             getRecordById("discount", customer_order.getDiscountId().toString());
@@ -709,7 +709,7 @@
         {            
             try
             {                 
-                getRecordById("Order", customer_order.getOrderId().toString());
+                getRecordById("`order`", customer_order.getOrderId().toString());
                 customer_order.setOrder(Order.process(rs));                                                       
             }
             catch (SQLException ex)

--- a/src/java/com/busy/engine/dao/OrderDaoImpl.java
+++ b/src/java/com/busy/engine/dao/OrderDaoImpl.java
@@ -125,7 +125,7 @@
             ArrayList<Order> order = new ArrayList<>();
             try
             {
-                getAllRecordsByTableName("order");
+                getAllRecordsByTableName("`order`");
                 while (rs.next())
                 {
                     order.add(Order.process(rs));
@@ -205,7 +205,7 @@
             {
                 try
                 {
-                    getRecordsByTableNameWithLimitOrOffset("order", limit, offset);
+                    getRecordsByTableNameWithLimitOrOffset("`order`", limit, offset);
                     while (rs.next())
                     {
                         orderList.add(Order.process(rs));
@@ -278,7 +278,7 @@
                 orderList = new ArrayList<Order>();
                 try
                 {
-                    getRecordsByTableNameWithLimitOrOffset("order", limit, offset);
+                    getRecordsByTableNameWithLimitOrOffset("`order`", limit, offset);
                     while (rs.next())
                     {
                         orderList.add(Order.process(rs));
@@ -350,7 +350,7 @@
             {
                 try
                 {
-                    getRecordsByColumnWithLimitOrOffset("order", Order.checkColumnName(columnName), columnValue, Order.isColumnNumeric(columnName), limit, offset);
+                    getRecordsByColumnWithLimitOrOffset("`order`", Order.checkColumnName(columnName), columnValue, Order.isColumnNumeric(columnName), limit, offset);
                     while (rs.next())
                     {
                         orderList.add(Order.process(rs));
@@ -381,7 +381,7 @@
                     c.setNumeric(Order.isColumnNumeric(c.getColumnName()));                
                 }
 
-                getAllRecordsByColumns("order", columns);
+                getAllRecordsByColumns("`order`", columns);
                 while (rs.next())
                 {
                     orderList.add(Order.process(rs));
@@ -432,7 +432,7 @@
                   
 
                 openConnection();
-                prepareStatement("INSERT INTO order(OrderDate,ShipDate,PaymentMethod,PurchaseOrder,TransactionId,AmountBilled,PaymentStatus,PendingReason,PaymentType,TransactionFee,CurrencyCode,PayerId,SubtotalAmount,DiscountAmount,TaxAmount,ShippingAmount,TotalAmount,RefundAmount,Notes,OrderStatus,ShippingId,AffiliateId) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);");                    
+                prepareStatement("INSERT INTO `order`(OrderDate,ShipDate,PaymentMethod,PurchaseOrder,TransactionId,AmountBilled,PaymentStatus,PendingReason,PaymentType,TransactionFee,CurrencyCode,PayerId,SubtotalAmount,DiscountAmount,TaxAmount,ShippingAmount,TotalAmount,RefundAmount,Notes,OrderStatus,ShippingId,AffiliateId) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);");                    
                 preparedStatement.setDate(1, new java.sql.Date(obj.getOrderDate().getTime()));
                 preparedStatement.setDate(2, new java.sql.Date(obj.getShipDate().getTime()));
                 preparedStatement.setString(3, obj.getPaymentMethod());
@@ -458,7 +458,7 @@
                 
                 preparedStatement.executeUpdate();
 
-                rs = statement.executeQuery("SELECT DISTINCT LAST_INSERT_Id() from order;");
+                rs = statement.executeQuery("SELECT DISTINCT LAST_INSERT_Id() from `order`;");
                 while (rs.next())
                 {
                     id = rs.getInt(1);
@@ -514,7 +514,7 @@
                 
                                   
                 openConnection();                           
-                prepareStatement("UPDATE order SET OrderDate=?,ShipDate=?,PaymentMethod=?,PurchaseOrder=?,TransactionId=?,AmountBilled=?,PaymentStatus=?,PendingReason=?,PaymentType=?,TransactionFee=?,CurrencyCode=?,PayerId=?,SubtotalAmount=?,DiscountAmount=?,TaxAmount=?,ShippingAmount=?,TotalAmount=?,RefundAmount=?,Notes=?,OrderStatus=?,ShippingId=?,AffiliateId=? WHERE OrderId=?;");                    
+                prepareStatement("UPDATE `order` SET OrderDate=?,ShipDate=?,PaymentMethod=?,PurchaseOrder=?,TransactionId=?,AmountBilled=?,PaymentStatus=?,PendingReason=?,PaymentType=?,TransactionFee=?,CurrencyCode=?,PayerId=?,SubtotalAmount=?,DiscountAmount=?,TaxAmount=?,ShippingAmount=?,TotalAmount=?,RefundAmount=?,Notes=?,OrderStatus=?,ShippingId=?,AffiliateId=? WHERE OrderId=?;");                    
                 preparedStatement.setDate(1, new java.sql.Date(obj.getOrderDate().getTime()));
                 preparedStatement.setDate(2, new java.sql.Date(obj.getShipDate().getTime()));
                 preparedStatement.setString(3, obj.getPaymentMethod());
@@ -566,7 +566,7 @@
             }
             else
             {
-                count = getAllRecordsCountByTableName("order");
+                count = getAllRecordsCountByTableName("`order`");
             }
             return count;
         }
@@ -612,7 +612,7 @@ order.setShipmentList(new ShipmentDaoImpl().findByColumn("OrderId", order.getOrd
             boolean success = false;
             try
             {
-                updateQuery("DELETE FROM order WHERE OrderId=" + obj.getOrderId() + ";");            
+                updateQuery("DELETE FROM `order` WHERE OrderId=" + obj.getOrderId() + ";");            
                 success = true;
             }
             catch (Exception ex)
@@ -638,7 +638,7 @@ order.setShipmentList(new ShipmentDaoImpl().findByColumn("OrderId", order.getOrd
             boolean success = false;      
             try
             {
-                updateQuery("DELETE FROM order WHERE OrderId=" + id + ";");           
+                updateQuery("DELETE FROM `order` WHERE OrderId=" + id + ";");           
                 success = true;           
             }
             catch (Exception ex)
@@ -664,7 +664,7 @@ order.setShipmentList(new ShipmentDaoImpl().findByColumn("OrderId", order.getOrd
             boolean success = false;
             try
             {
-                updateQuery("DELETE FROM order;");          
+                updateQuery("DELETE FROM `order`;");          
                 success = true;
             }
             catch (Exception ex)
@@ -690,7 +690,7 @@ order.setShipmentList(new ShipmentDaoImpl().findByColumn("OrderId", order.getOrd
             boolean success = false;
             try
             { 
-                updateQuery("DELETE FROM order WHERE " + Order.checkColumnName(columnName) + "=" + columnValue + ";");           
+                updateQuery("DELETE FROM `order` WHERE " + Order.checkColumnName(columnName) + "=" + columnValue + ";");           
                 success = true;       
             }
             catch (Exception ex)

--- a/src/java/com/busy/engine/dao/RecurringPaymentDaoImpl.java
+++ b/src/java/com/busy/engine/dao/RecurringPaymentDaoImpl.java
@@ -158,7 +158,7 @@
                 {
 
                 
-                    getRecordById("order", recurringPayment.getOrderId().toString());
+                    getRecordById("`order`", recurringPayment.getOrderId().toString());
                     recurringPayment.setOrder(Order.process(rs));               
                   
 
@@ -251,7 +251,7 @@
                             RecurringPayment recurringPayment = (RecurringPayment) e.getValue();
 
                             
-                                getRecordById("order", recurringPayment.getOrderId().toString());
+                                getRecordById("`order`", recurringPayment.getOrderId().toString());
                                 recurringPayment.setOrder(Order.process(rs));               
                                                     
                         }
@@ -283,7 +283,7 @@
                         for (RecurringPayment recurringPayment : recurringPaymentList)
                         {                        
                             
-                                getRecordById("order", recurringPayment.getOrderId().toString());
+                                getRecordById("`order`", recurringPayment.getOrderId().toString());
                                 recurringPayment.setOrder(Order.process(rs));               
                               
                         }
@@ -502,7 +502,7 @@
                 try
                 { 
                     
-                            getRecordById("order", recurring_payment.getOrderId().toString());
+                            getRecordById("`order`", recurring_payment.getOrderId().toString());
                             recurring_payment.setOrder(Order.process(rs));                                       
                     
                     }
@@ -666,7 +666,7 @@
         {            
             try
             {                 
-                getRecordById("Order", recurring_payment.getOrderId().toString());
+                getRecordById("`order`", recurring_payment.getOrderId().toString());
                 recurring_payment.setOrder(Order.process(rs));                                                       
             }
             catch (SQLException ex)

--- a/src/java/com/busy/engine/dao/ShipmentDaoImpl.java
+++ b/src/java/com/busy/engine/dao/ShipmentDaoImpl.java
@@ -158,7 +158,7 @@
                 {
 
                 
-                    getRecordById("order", shipment.getOrderId().toString());
+                    getRecordById("`order`", shipment.getOrderId().toString());
                     shipment.setOrder(Order.process(rs));               
                   
 
@@ -251,7 +251,7 @@
                             Shipment shipment = (Shipment) e.getValue();
 
                             
-                                getRecordById("order", shipment.getOrderId().toString());
+                                getRecordById("`order`", shipment.getOrderId().toString());
                                 shipment.setOrder(Order.process(rs));               
                                                     
                         }
@@ -283,7 +283,7 @@
                         for (Shipment shipment : shipmentList)
                         {                        
                             
-                                getRecordById("order", shipment.getOrderId().toString());
+                                getRecordById("`order`", shipment.getOrderId().toString());
                                 shipment.setOrder(Order.process(rs));               
                               
                         }
@@ -510,7 +510,7 @@
                 try
                 { 
                     
-                            getRecordById("order", shipment.getOrderId().toString());
+                            getRecordById("`order`", shipment.getOrderId().toString());
                             shipment.setOrder(Order.process(rs));                                       
                     
                     }
@@ -674,7 +674,7 @@
         {            
             try
             {                 
-                getRecordById("Order", shipment.getOrderId().toString());
+                getRecordById("`order`", shipment.getOrderId().toString());
                 shipment.setOrder(Order.process(rs));                                                       
             }
             catch (SQLException ex)

--- a/src/java/com/busy/engine/data/BasicConnection.java
+++ b/src/java/com/busy/engine/data/BasicConnection.java
@@ -102,7 +102,7 @@ public class BasicConnection
         }
         catch (Exception ex) 
         {
-            System.out.println("gtAllRecordsByTableName error: " + ex.getMessage());
+            System.out.println("getAllRecordsByTableName error: " + ex.getMessage());
         }   
     }
        

--- a/src/java/com/busy/engine/data/Database.java
+++ b/src/java/com/busy/engine/data/Database.java
@@ -356,7 +356,7 @@ public class Database extends BasicConnection
                            + "'," + paypalFeeCharged  +",'" + paypalCurrencyCode + "','" + paypalPayerId + "'," + orderTaxAmount + "," + orderShippingAmount + ",'" + orderAdditionalData + "');";
 
             updateQuery(query);
-            rs = statement.executeQuery("SELECT DISTINCT LAST_INSERT_Id() from order;");
+            rs = statement.executeQuery("SELECT DISTINCT LAST_INSERT_Id() from `order`;");
             while(rs.next())
             {
                 id =  rs.getString(1);

--- a/web/admin/CategoryUI.jsp
+++ b/web/admin/CategoryUI.jsp
@@ -299,7 +299,7 @@
                                                         <div class="input-icon right">
                                                             <i class="fa"></i>
                                                             <select name="parentCategoryId" class="form-control">
-                                                                <%= Database.generateSelectOptionsFromTableAndColumn("parent_category", "", 2)%>
+                                                                <%= Database.generateSelectOptionsFromTableAndColumn("category", "", 2)%>
                                                             </select>                                                            
                                                         </div>
                                                     </div>

--- a/web/admin/CustomerOrderUI.jsp
+++ b/web/admin/CustomerOrderUI.jsp
@@ -220,7 +220,7 @@ NumberFormat formatter = NumberFormat.getCurrencyInstance();
                                                     <div  class="col-md-10">
                                                         <input type="text" name="orderId" class="form-control" value="${customer_order.orderId}" />
                                                         <select name="orderId" class="form-control">
-                                                            <%= Database.generateSelectOptionsFromTableAndColumn("order", x.getOrderId().toString(), 2)%>
+                                                            <%= Database.generateSelectOptionsFromTableAndColumn("`order`", x.getOrderId().toString(), 2)%>
                                                         </select>
                                                     </div>
                                                 </div>
@@ -315,7 +315,7 @@ NumberFormat formatter = NumberFormat.getCurrencyInstance();
                                                             <div class="input-icon right">
                                                                 <i class="fa"></i>
                                                                 <select name="orderId" class="form-control">
-                                                                    <%= Database.generateSelectOptionsFromTableAndColumn("order", "", 2)%>
+                                                                    <%= Database.generateSelectOptionsFromTableAndColumn("`order`", "", 2)%>
                                                                </select>                                                            
                                                             </div>
                                                         </div>

--- a/web/admin/OrderUI.jsp
+++ b/web/admin/OrderUI.jsp
@@ -429,7 +429,7 @@ NumberFormat formatter = NumberFormat.getCurrencyInstance();
                                                             <div class="input-icon right">
                                                                 <i class="fa"></i>
                                                                 <select name="orderId" class="form-control">
-                                                                    <%= Database.generateSelectOptionsFromTableAndColumn("order", "", 2)%>
+                                                                    <%= Database.generateSelectOptionsFromTableAndColumn("`order`", "", 2)%>
                                                                </select>                                                            
                                                             </div>
                                                         </div>

--- a/web/admin/RecurringPaymentUI.jsp
+++ b/web/admin/RecurringPaymentUI.jsp
@@ -301,7 +301,7 @@ NumberFormat formatter = NumberFormat.getCurrencyInstance();
                                                         <input type="text" name="orderId" class="form-control" value="${recurring_payment.orderId}" />
                                                         <select name="orderId" class="form-control">
                                                             <%RecurringPayment x = (RecurringPayment) pageContext.getAttribute("recurring_payment"); %>
-                                                            <%= Database.generateSelectOptionsFromTableAndColumn("order", x.getOrderId().toString(), 2)%>
+                                                            <%= Database.generateSelectOptionsFromTableAndColumn("`order`", x.getOrderId().toString(), 2)%>
                                                         </select>
                                                     </div>
                                                 </div>
@@ -413,7 +413,7 @@ NumberFormat formatter = NumberFormat.getCurrencyInstance();
                                                             <div class="input-icon right">
                                                                 <i class="fa"></i>
                                                                 <select name="orderId" class="form-control">
-                                                                    <%= Database.generateSelectOptionsFromTableAndColumn("order", "", 2)%>
+                                                                    <%= Database.generateSelectOptionsFromTableAndColumn("`order`", "", 2)%>
                                                                </select>                                                            
                                                             </div>
                                                         </div>

--- a/web/admin/ShipmentUI.jsp
+++ b/web/admin/ShipmentUI.jsp
@@ -317,7 +317,7 @@ NumberFormat formatter = NumberFormat.getCurrencyInstance();
                                                         <input type="text" name="orderId" class="form-control" value="${shipment.orderId}" />
                                                         <select name="orderId" class="form-control">
                                                             <%Shipment x = (Shipment) pageContext.getAttribute("shipment"); %>
-                                                            <%= Database.generateSelectOptionsFromTableAndColumn("order", x.getOrderId().toString(), 2)%>
+                                                            <%= Database.generateSelectOptionsFromTableAndColumn("`order`", x.getOrderId().toString(), 2)%>
                                                         </select>
                                                     </div>
                                                 </div>
@@ -453,7 +453,7 @@ NumberFormat formatter = NumberFormat.getCurrencyInstance();
                                                             <div class="input-icon right">
                                                                 <i class="fa"></i>
                                                                 <select name="orderId" class="form-control">
-                                                                    <%= Database.generateSelectOptionsFromTableAndColumn("order", "", 2)%>
+                                                                    <%= Database.generateSelectOptionsFromTableAndColumn("`order`", "", 2)%>
                                                                </select>                                                            
                                                             </div>
                                                         </div>

--- a/web/admin/ShoppingCartUI.jsp
+++ b/web/admin/ShoppingCartUI.jsp
@@ -211,7 +211,7 @@ NumberFormat formatter = NumberFormat.getCurrencyInstance();
                                                     <label class="col-md-2 control-label" for="orderId">OrderId:</label>
                                                     <div  class="col-md-10">
                                                         <select name="orderId" class="form-control">
-                                                            <%= Database.generateSelectOptionsFromTableAndColumn("order", x.getOrderId().toString(), 2)%>
+                                                            <%= Database.generateSelectOptionsFromTableAndColumn("`order`", x.getOrderId().toString(), 2)%>
                                                         </select>
                                                     </div>
                                                 </div>

--- a/web/admin/TemplateUI.jsp
+++ b/web/admin/TemplateUI.jsp
@@ -267,7 +267,7 @@ switch(request.getParameter("columnValue")){
                                                     <div  class="col-md-10">
                                                         <input type="text" name="parentTemplateId" class="form-control" value="${template.parentTemplateId}" />
                                                         <select name="parentTemplateId" class="form-control">
-                                                            <%= Database.generateSelectOptionsFromTableAndColumn("parent_template", x.getParentTemplateId().toString(), 2)%>
+                                                            <%= Database.generateSelectOptionsFromTableAndColumn("template", x.getParentTemplateId().toString(), 2)%>
                                                         </select>
                                                     </div>
                                                 </div>
@@ -381,7 +381,7 @@ switch(request.getParameter("columnValue")){
                                                             <div class="input-icon right">
                                                                 <i class="fa"></i>
                                                                 <select name="parentTemplateId" class="form-control">
-                                                                    <%= Database.generateSelectOptionsFromTableAndColumn("parent_template", "", 2)%>
+                                                                    <%= Database.generateSelectOptionsFromTableAndColumn("template", "", 2)%>
                                                                </select>                                                            
                                                             </div>
                                                         </div>


### PR DESCRIPTION
Since order is considered as special keyword in SQL queries, all queries
on order table has to be wrapped with ` character. Therefore, "order" is
replaced by "`order`" in many places.
In addition, little modifications has been made to resolve some of
errors appeared when making queries to MySQL.